### PR TITLE
Update peerDependencies to allow sanity v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@operationnation/sanity-plugin-schema-markup",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@operationnation/sanity-plugin-schema-markup",
-      "version": "1.0.15",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@sanity/icons": "^2.7.0",
@@ -64,7 +64,7 @@
       },
       "peerDependencies": {
         "react": "^18",
-        "sanity": "^3"
+        "sanity": "^3 || ^4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "peerDependencies": {
     "react": "^18",
-    "sanity": "^3"
+    "sanity": "^3 || ^4"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
The only breaking change in [v4](https://www.sanity.io/docs/changelog/8946d096-c4f6-44af-999f-63d0f62e6e2d) is the Node version upgrade.
So plugin is stable, and should allow v4 as a peer
